### PR TITLE
fix GpioPinVariable call for pwm pins

### DIFF
--- a/AVRTools/GpioPinMacros.h
+++ b/AVRTools/GpioPinMacros.h
@@ -501,7 +501,7 @@ private:
                                                     GpioPinVariable( &(ddr), &(port), &(pin), nbr, adc )
 
 #define _makeGpioVarFromGpioPinPwm( ddr, port, pin, nbr, adc, ocr, com, tccr )      \
-                                                    GpioPinVariable( &(ddr), &(port), &(pin), nbr, ocr, tccr, com )
+                                                    GpioPinVariable( &(ddr), &(port), &(pin), nbr, &(ocr), &(tccr), com )
 
 
 


### PR DESCRIPTION
There was an error
avrtools/GpioPinMacros.h:415:3: note:   initializing argument 5 of 'GpioPinVariable::GpioPinVariable(Gpio8Ptr, Gpio8Ptr, Gpio8Ptr, int8_t, Gpio16Ptr, Gpio8Ptr, int8_t)'
   GpioPinVariable(Gpio8Ptr ddr, Gpio8Ptr port, Gpio8Ptr pin, int8_t nbr, Gpio16Ptr ocr, Gpio8Ptr tccr, int8_t com)